### PR TITLE
change license from Artistic to Apache 2.0

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
+# Chemdraw-Converter
+
 This distribution contains a library to read (and partially write)
 Chemdraw (CDX) files into/from CMLDOM. It is based on the web-published
 definition of CDX files on the cambridgesoft.com site and honours
 many of the components of a CDX file. It does not support Chemdraw-specific
 elements such as display types, fonts, etc.
 
-The code is made available under the Artistic license, http://www.opensource.org
-In general it may be freely distributed and modified, but the original authorship
-must be honoured and modified versions must use different names.
+The code is made available under the Apache License, Version 2.0,
+<https://www.apache.org/licenses/LICENSE-2.0>.
 
 Peter Murray-Rust,
-www.xml-cml.org, 2000
+www.xml-cml.org, 2020
 
-The current distribution is a library, not an application and will require a 
+The current distribution is a library, not an application and will require a
 CMLDOM for integration into a system. See http://www.xml-cml.org and
-http://wwmm.ch.cam.ac.uk/moin
-
+http://www-pmr.ch.cam.ac.uk/ and https://github.com/BlueObelisk

--- a/pom.xml
+++ b/pom.xml
@@ -86,11 +86,15 @@
 					</properties>
 					<excludes>
 						<exclude>**/README.md</exclude>
+						<exclude>pom.xml</exclude>
 						<exclude>LICENSE.txt</exclude>
 						<exclude>.gitignore</exclude>
 						<exclude>src/test/resources/**</exclude>
 						<exclude>src/main/resources/**</exclude>
 						<exclude>junk/**</exclude>
+						<exclude>**/*.xhtml</exclude>
+						<exclude>**/*.bat</exclude>
+						<exclude>**/*.xsl</exclude>
 					</excludes>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -2,32 +2,41 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<parent>
 		<groupId>uk.ac.cam.ch.wwmm</groupId>
 		<artifactId>wwmm-parent</artifactId>
 		<version>6</version>
-    </parent>
-    
+	</parent>
+
 	<groupId>org.xml-cml.chemdraw</groupId>
 	<artifactId>chemdraw-converter</artifactId>
 	<version>0.3-SNAPSHOT</version>
 	<name>Chemdraw-converters</name>
-	
+	<inceptionYear>2001</inceptionYear>
 	<description>Converts CDX and CDXML from and to CML</description>
 	<url>http://www.xml-cml.org/</url>
+
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
 	<scm />
-	
+
 	<properties>
-	    <chemdraw.groupId>org.xml-cml.chemdraw</chemdraw.groupId>
-	    
+		<chemdraw.groupId>org.xml-cml.chemdraw</chemdraw.groupId>
+
 		<junit.groupId>junit</junit.groupId>
 		<junit.artifactId>junit</junit.artifactId>
 		<junit.version>4.8.2</junit.version>
-		
-  	    <jumbo.groupId>org.xml-cml</jumbo.groupId>
+
+		<jumbo.groupId>org.xml-cml</jumbo.groupId>
 		<jumbo.version>6.1-SNAPSHOT</jumbo.version>
-		
+
 		<jumbo-testutil.version>1.1-SNAPSHOT</jumbo-testutil.version>
 	</properties>
 
@@ -63,10 +72,38 @@
 						<exclude>org/xmlcml/util/TestUtils.java</exclude>
 					</excludes>
 				</configuration>
-			</plugin>			
+			</plugin>
+			<!-- Licence Maven Plugin (add license info to source files) -->
+			<plugin>
+				<groupId>com.mycila</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+				<version>2.11</version>
+				<configuration>
+					<header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+					<properties>
+						<owner>Peter Murray-Rust</owner>
+						<email>pm286@cam.ac.uk</email>
+					</properties>
+					<excludes>
+						<exclude>**/README.md</exclude>
+						<exclude>LICENSE.txt</exclude>
+						<exclude>.gitignore</exclude>
+						<exclude>src/test/resources/**</exclude>
+						<exclude>src/main/resources/**</exclude>
+						<exclude>junk/**</exclude>
+					</excludes>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
-	
+
 	<dependencies>
 		<dependency>
 			<groupId>${jumbo.groupId}</groupId>
@@ -91,7 +128,7 @@
          <scope>test</scope>
       </dependency>
 	</dependencies>
-	
+
 	<reporting>
 		<plugins>
 			<plugin>

--- a/src/main/java/org/xmlcml/cml/chemdraw/CDX2CDXML.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/CDX2CDXML.java
@@ -18,11 +18,9 @@ import org.xmlcml.cml.chemdraw.components.ChemdrawRuntimeException;
  * relies on format on Chemdraw website.
  * some primitives (especially pure graphics) may not be
  * fully supported
- * 
-This code is open source under the Artistic License
-see http://www.opensource.org for conditions
-@author P.Murray-Rust, 2001-2008
-*/
+ *
+ * @author P.Murray-Rust, 2001-2008
+ **/
 
 
 public class CDX2CDXML {
@@ -35,7 +33,7 @@ public class CDX2CDXML {
 	private static final int BLOCKSIZE = 8 * ROWSIZE;
 	private CDXObject parsedObject;
 	private CDXParser parser;
-	
+
 	/**
      */
 	public CDX2CDXML() {
@@ -45,7 +43,7 @@ public class CDX2CDXML {
 	private void init() {
 		parser = new CDXParser();
 	}
-	
+
 	/**
 	 * @param is
 	 * @throws IOException
@@ -55,7 +53,7 @@ public class CDX2CDXML {
 		byte[] bytes = IOUtils.toByteArray(is);
 		this.parseCDX(bytes);
     }
-	
+
 	public CDXParser getParser() {
 		return parser;
 	}
@@ -138,7 +136,7 @@ public class CDX2CDXML {
 		}
 		return sb.toString();
 	}
-	
+
 	private static String toHexString(byte b) {
 		String s = Integer.toHexString((int)b);
 		StringBuilder sb = new StringBuilder(s);
@@ -149,7 +147,7 @@ public class CDX2CDXML {
 		}
 		return sb.toString();
 	}
-	
+
 	private static String toHexString(int i) {
 		String s = Integer.toHexString(i);
 		StringBuilder sb = new StringBuilder(s);
@@ -189,7 +187,7 @@ public class CDX2CDXML {
 		System.out.println("======================================BYTES "+newBytes.length);
 		return newBytes;
 	}
-	
+
 	private static byte[] exciseBlock(byte[] bytes, int byteCount) {
 		int leftover = bytes.length % BLOCKSIZE;
 		if (leftover != 0) {
@@ -206,10 +204,5 @@ public class CDX2CDXML {
 		System.out.println("======================================BYTES "+newBytes.length);
 		return newBytes;
 	}
-	
+
 };
-
-
-
-
-

--- a/src/main/java/org/xmlcml/cml/chemdraw/CDX2CDXML.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/CDX2CDXML.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw;
 
 import java.io.ByteArrayInputStream;

--- a/src/main/java/org/xmlcml/cml/chemdraw/CDXConstants.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/CDXConstants.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw; 
 
 import org.xmlcml.cml.base.CMLConstants;

--- a/src/main/java/org/xmlcml/cml/chemdraw/CDXML2CMLProcessor.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/CDXML2CMLProcessor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw;
 
 import static org.xmlcml.cml.base.CMLConstants.CMLXSD_ID;

--- a/src/main/java/org/xmlcml/cml/chemdraw/CDXRawToCMLCreator.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/CDXRawToCMLCreator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw;
 
 import org.apache.log4j.Logger;

--- a/src/main/java/org/xmlcml/cml/chemdraw/ChemDrawReactionConverter.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/ChemDrawReactionConverter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw;
 
 import java.util.List;

--- a/src/main/java/org/xmlcml/cml/chemdraw/XMLToCDXMLConverter.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/XMLToCDXMLConverter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw;
 
 import java.util.HashMap;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/BlockManager.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/BlockManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 import org.apache.log4j.Logger;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/BlockManager.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/BlockManager.java
@@ -5,10 +5,8 @@ import org.xmlcml.cml.chemdraw.CDXConstants;
 
 
 /**
-This code is open source under the Artistic License
-see http://www.opensource.org for conditions
-@author P.Murray-Rust, 2001-2004
-*/
+ * @author P.Murray-Rust, 2001-2004
+ **/
 
 
 public class BlockManager implements CDXConstants {
@@ -100,4 +98,3 @@ class Block implements CDXConstants {
 //        return bytes[currentByte++];
 //    }
 }
-

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/BoundingBox.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/BoundingBox.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 import java.util.StringTokenizer;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXArrow.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXArrow.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXBond.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXBond.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXBracketAttachment.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXBracketAttachment.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXBracketedGroup.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXBracketedGroup.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXColorTable.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXColorTable.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXCoordinate.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXCoordinate.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXCurve.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXCurve.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXDataType.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXDataType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 import org.apache.log4j.Level;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXFontTable.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXFontTable.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXFragment.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXFragment.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 import java.util.List;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXGeometry.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXGeometry.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 import java.util.StringTokenizer;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXGraphic.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXGraphic.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXGroup.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXGroup.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXList.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXList.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXML.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXML.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXNode.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXNode.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXObject.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXObject.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 import java.util.Hashtable;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXObjectTag.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXObjectTag.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXPage.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXPage.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXParser.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXParser.java
@@ -10,10 +10,8 @@ import org.apache.log4j.Logger;
 import org.xmlcml.cml.chemdraw.CDXConstants;
 
 /**
-This code is open source under the Artistic License
-see http://www.opensource.org for conditions
-@author P.Murray-Rust, 2001-2004
-*/
+ * @author P.Murray-Rust, 2001-2004
+ **/
 
 public class CDXParser implements CDXConstants {
 
@@ -74,7 +72,7 @@ public class CDXParser implements CDXConstants {
 		bytes = IOUtils.toByteArray(is);
 		parseCDX();
 	}
-	
+
     /** read data from an input stream.
     * @param is the InputStream
     * @throws IOException
@@ -87,7 +85,7 @@ public class CDXParser implements CDXConstants {
     	parseBlocks();
     }
 
-	
+
 
 	private void makeBlocks(byte[] bytes) {
         blockManager = new BlockManager();
@@ -248,7 +246,7 @@ public class CDXParser implements CDXConstants {
 					"UNKNOWN PROP : "+propS+"("+CDXUtil.toXHex(iProp)+")"+
 					") at byte "+byteCount+"/"+Integer.toHexString(byteCount)+" in "+bb.length);
 			throw new ChemdrawRuntimeException("UNKNOWN PROP");
-			
+
 		} else {
             LOG.trace("PROPERTY ... "+prop.getCDXName());
 		}
@@ -307,7 +305,7 @@ public class CDXParser implements CDXConstants {
 		}
 		LOG.trace("ByteCount "+byteCount);
 	}
-	
+
 	private void processObject(byte[] bb) {
 		LOG.debug("processObject");
 //		MYFINE = Level.INFO;
@@ -343,8 +341,3 @@ public class CDXParser implements CDXConstants {
 	}
 
 };
-
-
-
-
-

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXParser.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXParser.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 import java.io.IOException;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXPoint2D.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXPoint2D.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 import java.util.StringTokenizer;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXPoint3D.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXPoint3D.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 import java.util.StringTokenizer;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXProperty.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXProperty.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 import java.util.Hashtable;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXReactionScheme.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXReactionScheme.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXReactionStep.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXReactionStep.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 import java.util.ArrayList;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXRectangle.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXRectangle.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 import java.util.StringTokenizer;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXText.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXText.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CDXUtil.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CDXUtil.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components; 
 
 import org.apache.log4j.Logger;

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/ChemdrawRuntimeException.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/ChemdrawRuntimeException.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 public class ChemdrawRuntimeException extends RuntimeException {

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/CodeName.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/CodeName.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 public class CodeName {

--- a/src/main/java/org/xmlcml/cml/chemdraw/components/Style.java
+++ b/src/main/java/org/xmlcml/cml/chemdraw/components/Style.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw.components;
 
 public class Style {

--- a/src/main/java/org/xmlcml/cml/chemdraw/license.txt
+++ b/src/main/java/org/xmlcml/cml/chemdraw/license.txt
@@ -1,7 +1,0 @@
-/** 
-This code is open source under the Artistic License 
-see http://www.opensource.org for conditions
-@author P.Murray-Rust, 2001-2004
-*/
-
-

--- a/src/test/java/org/xmlcml/cml/chemdraw/ChemDrawConverterTest.java
+++ b/src/test/java/org/xmlcml/cml/chemdraw/ChemDrawConverterTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.cml.chemdraw;
 
 import java.io.File;

--- a/src/test/java/org/xmlcml/util/TestUtils.java
+++ b/src/test/java/org/xmlcml/util/TestUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2001 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.util;
 
 import java.io.File;


### PR DESCRIPTION
These commits remove references to the Artistic license and add the Apache 2.0 license:

* mentioned in `README.md`
* full text in `LICENSE.txt`
* listed in `pom.xml`
* license headers in all `*.java` files

fixes #4 